### PR TITLE
Add basic audio streaming functionality

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,21 +1,27 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_sound (0.0.1):
+  - just_audio (0.0.1):
+    - Flutter
+  - path_provider (0.0.1):
     - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
+  - just_audio (from `.symlinks/plugins/just_audio/ios`)
+  - path_provider (from `.symlinks/plugins/path_provider/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  flutter_sound:
-    :path: ".symlinks/plugins/flutter_sound/ios"
+  just_audio:
+    :path: ".symlinks/plugins/just_audio/ios"
+  path_provider:
+    :path: ".symlinks/plugins/path_provider/ios"
 
 SPEC CHECKSUMS:
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  flutter_sound: 0e8163ceac1e00eb6d894e2ae4641ba726a2c479
+  just_audio: c695d6e7e37f9e96672dd84039d7530e7fd5c205
+  path_provider: fb74bd0465e96b594bb3b5088ee4a4e7bb1f2a9d
 
 PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
 
 void main() => runApp(CodeRadioApp());
 
@@ -37,6 +38,34 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
+  AudioPlayer _player;
+  bool _isPlaying = false;
+
+  void _play() async {
+    // TODO: Fetch available path
+    _player = AudioPlayer();
+    String _streamPath =
+        "https://coderadio-admin.freecodecamp.org/radio/8010/radio.mp3";
+    await _player.setUrl(_streamPath);
+    _player.play();
+  }
+
+  void _stop() async {
+    await _player.stop();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _player = AudioPlayer();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _player.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -47,15 +76,19 @@ class _HomePageState extends State<HomePage> {
             style: TextStyle(color: Color.fromARGB(255, 10, 10, 35))),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text(
-              'Play',
-            ),
-          ],
-        ),
-      ),
+          child: IconButton(
+        icon: _isPlaying ? Icon(Icons.stop) : Icon(Icons.play_arrow),
+        onPressed: () {
+          if (_isPlaying) {
+            _stop();
+          } else {
+            _play();
+          }
+          setState(() {
+            _isPlaying = !_isPlaying;
+          });
+        },
+      )),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 
+enum PlayerStatus { playing, stopped, loading }
+
 void main() => runApp(CodeRadioApp());
 
 Map<int, Color> primaryColorSwatch = {
@@ -39,19 +41,28 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   AudioPlayer _player;
-  bool _isPlaying = false;
+  PlayerStatus _playerStatus = PlayerStatus.stopped;
 
   void _play() async {
+    setState(() {
+      _playerStatus = PlayerStatus.loading;
+    });
     // TODO: Fetch available path
     _player = AudioPlayer();
     String _streamPath =
         "https://coderadio-admin.freecodecamp.org/radio/8010/radio.mp3";
     await _player.setUrl(_streamPath);
     _player.play();
+    setState(() {
+      _playerStatus = PlayerStatus.playing;
+    });
   }
 
   void _stop() async {
     await _player.stop();
+    setState(() {
+      _playerStatus = PlayerStatus.stopped;
+    });
   }
 
   @override
@@ -76,19 +87,20 @@ class _HomePageState extends State<HomePage> {
             style: TextStyle(color: Color.fromARGB(255, 10, 10, 35))),
       ),
       body: Center(
-          child: IconButton(
-        icon: _isPlaying ? Icon(Icons.stop) : Icon(Icons.play_arrow),
-        onPressed: () {
-          if (_isPlaying) {
-            _stop();
-          } else {
-            _play();
-          }
-          setState(() {
-            _isPlaying = !_isPlaying;
-          });
-        },
-      )),
+          child: _playerStatus == PlayerStatus.loading
+              ? CircularProgressIndicator()
+              : IconButton(
+                  icon: _playerStatus == PlayerStatus.playing
+                      ? Icon(Icons.stop)
+                      : Icon(Icons.play_arrow),
+                  onPressed: () {
+                    if (_playerStatus == PlayerStatus.playing) {
+                      _stop();
+                    } else {
+                      _play();
+                    }
+                  },
+                )),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,24 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.4"
+  just_audio:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: "788aee577ab9cdd20f6d521369d3d7791b1ec0a9"
+      url: "git://github.com/ryanheise/just_audio.git"
+    source: git
+    version: "0.0.2"
+  logs:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: HEAD
+      resolved-ref: f6925356570f234dc129af9c427adbc331b9ae60
+      url: "git://github.com/pq/logs.git"
+    source: git
+    version: "0.0.1"
   matcher:
     dependency: transitive
     description:
@@ -102,6 +120,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   pedantic:
     dependency: transitive
     description:
@@ -116,6 +141,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   quiver:
     dependency: transitive
     description:
@@ -123,6 +155,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.23.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -199,4 +238,5 @@ packages:
     source: hosted
     version: "3.5.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"
+  flutter: ">=1.10.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,12 @@ dependencies:
   flutter:
     sdk: flutter
   web_socket_channel: ^1.1.0
+  just_audio:
+    git:
+      url: git://github.com/ryanheise/just_audio.git
+  logs:
+    git:
+      url: git://github.com/pq/logs.git
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
Add just_audio as a dependency and write simple code for streaming a hard-coded URL from the of one of the Code Radio streams. 

Reloads the stream when starting from a paused/stopped position to ensure that the audio stream lines up with the websocket information (to be implemented next).
*Note that the stop() function of the just_audio library will start the currently loaded stream from its starting position. This causes a misalignment with the websocket information.